### PR TITLE
Add listKeys

### DIFF
--- a/src/Crypto/Gpgme.hs
+++ b/src/Crypto/Gpgme.hs
@@ -45,6 +45,7 @@ module Crypto.Gpgme (
     -- * Keys
     , Key
     , getKey
+    , listKeys
     , freeKey
     , withKey
 

--- a/test/KeyTest.hs
+++ b/test/KeyTest.hs
@@ -9,6 +9,8 @@ import Crypto.Gpgme
 
 tests = [ testCase "get_alice_pub_from_alice" get_alice_pub_from_alice
         , testCase "get_bob_pub_from_alice" get_bob_pub_from_alice
+        , testCase "alice_list_pub_keys" alice_list_pub_keys
+        , testCase "alice_list_secret_keys" alice_list_secret_keys
         , testCase "get_inexistent_from_alice" get_inexistent_pub_from_alice
         , testCase "with_inexistent_from_alice" with_inexistent_from_alice
         , testCase "with_alice_pub_from_alice" with_alice_pub_from_alice
@@ -29,6 +31,18 @@ get_bob_pub_from_alice = do
         do key <- getKey ctx bob_pub_fpr NoSecret
            isJust key @? "missing " ++ show bob_pub_fpr
            freeKey (fromJust key)
+
+alice_list_pub_keys :: Assertion
+alice_list_pub_keys = do
+    withCtx "test/alice" "C" OpenPGP $ \ctx ->
+        do keys <- listKeys ctx NoSecret
+           length keys @?= 2
+
+alice_list_secret_keys :: Assertion
+alice_list_secret_keys = do
+    withCtx "test/alice" "C" OpenPGP $ \ctx ->
+        do keys <- listKeys ctx WithSecret
+           length keys @?= 1
 
 get_inexistent_pub_from_alice :: Assertion
 get_inexistent_pub_from_alice = do


### PR DESCRIPTION
This adds support for listing public and private keys

Note that the tests at the moment only verify the number of keys returned as we currently don't have the ability to look at any other traits of a key.