### PR TITLE
Simplify memory management and error handling for keys

### DIFF
--- a/h-gpgme.cabal
+++ b/h-gpgme.cabal
@@ -32,6 +32,7 @@ library
   build-depends:       base           == 4.*
                      , bindings-gpgme >= 0.1 && <0.2
                      , bytestring     >= 0.9
+                     , either         >= 4.3 && <5.0
                      , unix           >= 2.5
   default-language:    Haskell2010
 
@@ -45,6 +46,8 @@ test-suite tests
   build-depends:       base           == 4.*
                      , bindings-gpgme >= 0.1 && <0.2
                      , bytestring     >= 0.9
+                     , either         >= 4.3 && <5.0
+                     , transformers   >= 0.3 && <0.5
                      , unix           >= 2.5
 
                      , HUnit                      == 1.2.*

--- a/src/Crypto/Gpgme.hs
+++ b/src/Crypto/Gpgme.hs
@@ -46,7 +46,6 @@ module Crypto.Gpgme (
     , Key
     , getKey
     , listKeys
-    , withKey
 
     -- * Encryption
     , encrypt

--- a/src/Crypto/Gpgme.hs
+++ b/src/Crypto/Gpgme.hs
@@ -46,7 +46,6 @@ module Crypto.Gpgme (
     , Key
     , getKey
     , listKeys
-    , freeKey
     , withKey
 
     -- * Encryption

--- a/src/Crypto/Gpgme.hs
+++ b/src/Crypto/Gpgme.hs
@@ -45,6 +45,7 @@ module Crypto.Gpgme (
     -- * Keys
     , Key
     , getKey
+    , listKeys
     , freeKey
     , withKey
 

--- a/src/Crypto/Gpgme/Crypto.hs
+++ b/src/Crypto/Gpgme/Crypto.hs
@@ -14,6 +14,7 @@ module Crypto.Gpgme.Crypto (
 import Bindings.Gpgme
 import qualified Data.ByteString as BS
 import Foreign
+import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import GHC.Ptr
 
 import Crypto.Gpgme.Ctx
@@ -82,17 +83,12 @@ encryptIntern enc_op (Ctx ctxPtr _) recPtrs flag plain = do
     resultBufPtr <- newDataBuffer
     resultBuf <- peek resultBufPtr
 
-    -- null terminated array of recipients
-    recArray <- if null recPtrs
-                    then return nullPtr
-                    else do keys <- mapM (peek . unKey) recPtrs
-                            newArray (keys ++ [nullPtr])
-
     ctx <- peek ctxPtr
 
     -- encrypt
-    checkError "op_encrypt" =<< enc_op ctx recArray (fromFlag flag)
-                                    plainBuf resultBuf
+    withKeyPtrArray recPtrs $ \recArray -> 
+        checkError "op_encrypt" =<< enc_op ctx recArray (fromFlag flag)
+                                        plainBuf resultBuf
     free plainBufPtr
 
     -- check whether all keys could be used for encryption
@@ -107,6 +103,13 @@ encryptIntern enc_op (Ctx ctxPtr _) recPtrs flag plain = do
     free resultBufPtr
 
     return res
+
+-- | Build a null-terminated array of pointers from a list of 'Key's
+withKeyPtrArray :: [Key] -> (Ptr C'gpgme_key_t -> IO a) -> IO a
+withKeyPtrArray [] f   = f nullPtr
+withKeyPtrArray keys f = do
+    arr <- newArray0 nullPtr =<< mapM (peek . unsafeForeignPtrToPtr . unKey) keys
+    f arr
 
 -- | Convenience wrapper around 'withCtx' and 'withKey' to
 --   decrypt a single ciphertext with its homedirectory.

--- a/src/Crypto/Gpgme/Key.hs
+++ b/src/Crypto/Gpgme/Key.hs
@@ -1,7 +1,6 @@
 module Crypto.Gpgme.Key (
       getKey
     , listKeys
-    , withKey
     ) where
 
 import Bindings.Gpgme
@@ -31,9 +30,7 @@ listKeys (Ctx ctxPtr _) secret = do
     go []
 
 -- | Returns a 'Key' from the @context@ based on its @fingerprint@.
---   As a 'Key' returned from the function needs to be freed
---   with 'freeKey', the use of 'withKey' is encouraged. Returns
---   Nothing if no 'Key' with this 'Fpr' exists.
+--   Returns 'Nothing' if no 'Key' with this 'Fpr' exists.
 getKey :: Ctx           -- ^ context to operate in
        -> Fpr           -- ^ fingerprint
        -> IncludeSecret -- ^ whether to include secrets when searching for the key
@@ -47,21 +44,3 @@ getKey (Ctx ctxPtr _) fpr secret = do
     if ret == noError
         then return . Just $ key
         else return Nothing
-
--- | Conveniently runs the @action@ with the 'Key' associated
---   with the 'Fpr' in the 'Ctx' and frees it afterwards.
---   If no 'Key' with this 'Fpr' exists, Nothing is returned.
-
-withKey :: Ctx           -- ^ context to operate in
-        -> Fpr           -- ^ fingerprint
-        -> IncludeSecret -- ^ whether to include secrets when searching for the key
-        -> (Key -> IO a) -- ^ action to be run with key
-        -> IO (Maybe a)
-withKey ctx fpr is f = do 
-    mbkey <- getKey ctx fpr is
-    case mbkey of
-        Just key -> do res <- f key
-                       return (Just res)
-        Nothing -> return Nothing
-
-

--- a/src/Crypto/Gpgme/Types.hs
+++ b/src/Crypto/Gpgme/Types.hs
@@ -32,7 +32,15 @@ type InvalidKey = (String, Int)
 -- TODO map intot better error code
 
 -- | A key from the context
-newtype Key = Key { unKey :: Ptr C'gpgme_key_t }
+newtype Key = Key { unKey :: ForeignPtr C'gpgme_key_t }
+
+-- | Allocate a key
+allocKey :: IO Key
+allocKey = Key `fmap` mallocForeignPtr
+
+-- | Perform an action with the pointer to a 'Key'
+withKeyPtr :: Key -> (Ptr C'gpgme_key_t -> IO a) -> IO a
+withKeyPtr (Key fPtr) f = withForeignPtr fPtr f
 
 -- | Whether to include secret keys when searching
 data IncludeSecret =

--- a/test/CryptoTest.hs
+++ b/test/CryptoTest.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 module CryptoTest (tests) where
 
+import Control.Monad (liftM)
+import Control.Monad.Trans.Maybe
 import Data.List (isInfixOf)
 import Data.ByteString.Char8 ()
 import qualified Data.ByteString as BS
@@ -27,6 +29,9 @@ tests = [ testProperty "bob_encrypt_for_alice_decrypt"
         , testCase "bob_encrypt_symmetrically" bob_encrypt_symmetrically
         ]
 
+hush :: Monad m => m (Either e a) -> MaybeT m a
+hush = MaybeT . liftM (either (const Nothing) Just)
+
 bob_encrypt_for_alice_decrypt :: Plain -> Property
 bob_encrypt_for_alice_decrypt plain =
     not (BS.null plain) ==> monadicIO $ do
@@ -36,13 +41,13 @@ bob_encrypt_for_alice_decrypt plain =
             do let alice_pub_fpr = "EAACEB8A"
 
                -- encrypt
-               enc <- withCtx "test/bob" "C" OpenPGP $ \bCtx ->
-                       withKey bCtx alice_pub_fpr NoSecret $ \aPubKey ->
-                           encrypt bCtx [aPubKey] NoFlag plain
+               Just enc <- withCtx "test/bob" "C" OpenPGP $ \bCtx -> runMaybeT $ do
+                       aPubKey <- MaybeT $ getKey bCtx alice_pub_fpr NoSecret
+                       hush $ encrypt bCtx [aPubKey] NoFlag plain
 
                -- decrypt
                dec <- withCtx "test/alice" "C" OpenPGP $ \aCtx ->
-                       decrypt aCtx (fromJustAndRight enc)
+                       decrypt aCtx enc
 
                return $ fromRight dec
 
@@ -71,13 +76,13 @@ bob_encrypt_sign_for_alice_decrypt_verify plain =
             do let alice_pub_fpr = "EAACEB8A"
 
                -- encrypt
-               enc <- withCtx "test/bob" "C" OpenPGP $ \bCtx ->
-                       withKey bCtx alice_pub_fpr NoSecret $ \aPubKey ->
-                           encryptSign bCtx [aPubKey] NoFlag plain
+               Just enc <- withCtx "test/bob" "C" OpenPGP $ \bCtx -> runMaybeT $ do
+                       aPubKey <- MaybeT $ getKey bCtx alice_pub_fpr NoSecret
+                       hush $ encryptSign bCtx [aPubKey] NoFlag plain
 
                -- decrypt
                dec <- withCtx "test/alice" "C" OpenPGP $ \aCtx ->
-                       decryptVerify aCtx (fromJustAndRight enc)
+                       decryptVerify aCtx enc
 
                return $ fromRight dec
 

--- a/test/KeyTest.hs
+++ b/test/KeyTest.hs
@@ -9,6 +9,8 @@ import Crypto.Gpgme
 
 tests = [ testCase "get_alice_pub_from_alice" get_alice_pub_from_alice
         , testCase "get_bob_pub_from_alice" get_bob_pub_from_alice
+        , testCase "alice_list_pub_keys" alice_list_pub_keys
+        , testCase "alice_list_secret_keys" alice_list_secret_keys
         , testCase "get_inexistent_from_alice" get_inexistent_pub_from_alice
         , testCase "with_inexistent_from_alice" with_inexistent_from_alice
         , testCase "with_alice_pub_from_alice" with_alice_pub_from_alice
@@ -29,6 +31,18 @@ get_bob_pub_from_alice = do
         do key <- getKey ctx bob_pub_fpr NoSecret
            isJust key @? "missing " ++ show bob_pub_fpr
            freeKey (fromJust key)
+
+alice_list_pub_keys :: Assertion
+alice_list_pub_keys = do
+    withCtx "test/alice" "C" OpenPGP $ \ctx ->
+        do keys <- listKeys ctx NoSecret
+           length keys @?= 2
+
+alice_list_secret_keys :: Assertion
+alice_list_secret_keys = do
+    withCtx "test/alice" "C" OpenPGP $ \ctx ->
+        do keys <- listKeys ctx WithSecret
+           length keys @?= 1
 
 get_inexistent_pub_from_alice :: Assertion
 get_inexistent_pub_from_alice = do

--- a/test/KeyTest.hs
+++ b/test/KeyTest.hs
@@ -12,8 +12,6 @@ tests = [ testCase "get_alice_pub_from_alice" get_alice_pub_from_alice
         , testCase "alice_list_pub_keys" alice_list_pub_keys
         , testCase "alice_list_secret_keys" alice_list_secret_keys
         , testCase "get_inexistent_from_alice" get_inexistent_pub_from_alice
-        , testCase "with_inexistent_from_alice" with_inexistent_from_alice
-        , testCase "with_alice_pub_from_alice" with_alice_pub_from_alice
         ]
 
 get_alice_pub_from_alice :: Assertion
@@ -48,20 +46,3 @@ get_inexistent_pub_from_alice = do
     withCtx "test/alice/" "C" OpenPGP $ \ctx ->
         do key <- getKey ctx inexistent_fpr NoSecret
            isNothing key @? "existing " ++ show inexistent_fpr
-
-with_inexistent_from_alice :: Assertion
-with_inexistent_from_alice = do
-    let inexistent_fpr = "ABCDEF"
-    withCtx "test/alice/" "C" OpenPGP $ \ctx ->
-        do res <- withKey ctx inexistent_fpr NoSecret $ \_ -> do
-                    assertFailure "should not run action"
-           isNothing res @? "should be nothing"
-
-with_alice_pub_from_alice :: Assertion
-with_alice_pub_from_alice = do
-    let alice_pub_fpr = "EAACEB8A"
-    withCtx "test/alice/" "C" OpenPGP $ \ctx ->
-        do res <- withKey ctx alice_pub_fpr NoSecret $ \_ -> do
-                    return ("foo" :: String)
-           isJust res @? "should be just"
-           fromJust res @?= "foo"

--- a/test/KeyTest.hs
+++ b/test/KeyTest.hs
@@ -22,7 +22,6 @@ get_alice_pub_from_alice = do
     withCtx "test/alice" "C" OpenPGP $ \ctx ->
         do key <- getKey ctx alice_pub_fpr NoSecret
            isJust key @? "missing " ++ show alice_pub_fpr
-           freeKey (fromJust key)
 
 get_bob_pub_from_alice :: Assertion
 get_bob_pub_from_alice = do
@@ -30,7 +29,6 @@ get_bob_pub_from_alice = do
     withCtx "test/alice/" "C" OpenPGP $ \ctx ->
         do key <- getKey ctx bob_pub_fpr NoSecret
            isJust key @? "missing " ++ show bob_pub_fpr
-           freeKey (fromJust key)
 
 alice_list_pub_keys :: Assertion
 alice_list_pub_keys = do


### PR DESCRIPTION
This set depends upon #3.

We use `ForeignPtr`s instead of bare `Ptr`s to track keys, freeing the user from the burden of needing to manually manage their lifecycle and patching up a memory leak in the process. This allows us to eliminate the `withKey` construction. The `either` and `transformers` dependencies are used for error handling.