### PR TITLE
Support for probing various attributes of keys

### DIFF
--- a/h-gpgme.cabal
+++ b/h-gpgme.cabal
@@ -32,6 +32,7 @@ library
   build-depends:       base           == 4.*
                      , bindings-gpgme >= 0.1 && <0.2
                      , bytestring     >= 0.9
+                     , either         >= 4.3 && <5.0
                      , unix           >= 2.5
   default-language:    Haskell2010
 
@@ -45,6 +46,8 @@ test-suite tests
   build-depends:       base           == 4.*
                      , bindings-gpgme >= 0.1 && <0.2
                      , bytestring     >= 0.9
+                     , either         >= 4.3 && <5.0
+                     , transformers   >= 0.3 && <0.5
                      , unix           >= 2.5
 
                      , HUnit                      == 1.2.*

--- a/h-gpgme.cabal
+++ b/h-gpgme.cabal
@@ -33,6 +33,7 @@ library
                      , bindings-gpgme >= 0.1 && <0.2
                      , bytestring     >= 0.9
                      , either         >= 4.3 && <5.0
+                     , time           >= 1.4 && <2.0
                      , unix           >= 2.5
   default-language:    Haskell2010
 
@@ -48,6 +49,7 @@ test-suite tests
                      , bytestring     >= 0.9
                      , either         >= 4.3 && <5.0
                      , transformers   >= 0.3 && <0.5
+                     , time           >= 1.4 && <2.0
                      , unix           >= 2.5
 
                      , HUnit                      == 1.2.*

--- a/h-gpgme.cabal
+++ b/h-gpgme.cabal
@@ -30,7 +30,7 @@ library
                      , Crypto.Gpgme.Internal
                      , Crypto.Gpgme.Types
   build-depends:       base           == 4.*
-                     , bindings-gpgme >= 0.1 && <0.2
+                     , bindings-gpgme >= 0.1.6 && <0.2
                      , bytestring     >= 0.9
                      , either         >= 4.3 && <5.0
                      , time           >= 1.4 && <2.0
@@ -45,7 +45,7 @@ test-suite tests
   hs-source-dirs:      src, test
   main-is:             Main.hs
   build-depends:       base           == 4.*
-                     , bindings-gpgme >= 0.1 && <0.2
+                     , bindings-gpgme >= 0.1.6 && <0.2
                      , bytestring     >= 0.9
                      , either         >= 4.3 && <5.0
                      , transformers   >= 0.3 && <0.5

--- a/src/Crypto/Gpgme.hs
+++ b/src/Crypto/Gpgme.hs
@@ -46,7 +46,6 @@ module Crypto.Gpgme (
     , Key
     , getKey
     , listKeys
-    , withKey
 
     -- * Encryption
     , encrypt

--- a/src/Crypto/Gpgme.hs
+++ b/src/Crypto/Gpgme.hs
@@ -46,6 +46,15 @@ module Crypto.Gpgme (
     , Key
     , getKey
     , listKeys
+    -- * Information about keys
+    , Validity (..)
+    , PubKeyAlgo (..)
+    , KeySignature (..)
+    , UserId (..)
+    , KeyUserId (..)
+    , keyUserIds
+    , SubKey (..)
+    , keySubKeys
 
     -- * Encryption
     , encrypt

--- a/src/Crypto/Gpgme.hs
+++ b/src/Crypto/Gpgme.hs
@@ -46,7 +46,6 @@ module Crypto.Gpgme (
     , Key
     , getKey
     , listKeys
-    , freeKey
     , withKey
 
     -- * Encryption

--- a/src/Crypto/Gpgme/Crypto.hs
+++ b/src/Crypto/Gpgme/Crypto.hs
@@ -14,6 +14,7 @@ module Crypto.Gpgme.Crypto (
 import Bindings.Gpgme
 import qualified Data.ByteString as BS
 import Foreign
+import Foreign.ForeignPtr.Unsafe (unsafeForeignPtrToPtr)
 import GHC.Ptr
 
 import Crypto.Gpgme.Ctx
@@ -82,17 +83,12 @@ encryptIntern enc_op (Ctx ctxPtr _) recPtrs flag plain = do
     resultBufPtr <- newDataBuffer
     resultBuf <- peek resultBufPtr
 
-    -- null terminated array of recipients
-    recArray <- if null recPtrs
-                    then return nullPtr
-                    else do keys <- mapM (peek . unKey) recPtrs
-                            newArray (keys ++ [nullPtr])
-
     ctx <- peek ctxPtr
 
     -- encrypt
-    checkError "op_encrypt" =<< enc_op ctx recArray (fromFlag flag)
-                                    plainBuf resultBuf
+    withKeyPtrArray recPtrs $ \recArray -> 
+        checkError "op_encrypt" =<< enc_op ctx recArray (fromFlag flag)
+                                        plainBuf resultBuf
     free plainBufPtr
 
     -- check whether all keys could be used for encryption
@@ -107,6 +103,13 @@ encryptIntern enc_op (Ctx ctxPtr _) recPtrs flag plain = do
     free resultBufPtr
 
     return res
+
+-- | Build a null-terminated array of pointers from a list of 'Key's
+withKeyPtrArray :: [Key] -> (Ptr C'gpgme_key_t -> IO a) -> IO a
+withKeyPtrArray [] f   = f nullPtr
+withKeyPtrArray keys f = do
+    arr <- newArray0 nullPtr =<< mapM (peek . unsafeForeignPtrToPtr . unKey) keys
+    f arr
 
 -- | Convenience wrapper around 'withCtx' and 'withKey' to
 --   decrypt a single ciphertext with its homedirectory.

--- a/src/Crypto/Gpgme/Internal.hs
+++ b/src/Crypto/Gpgme/Internal.hs
@@ -25,7 +25,7 @@ collectResult dat' = unsafePerformIO $ do
     _ <- c'gpgme_data_seek dat' 0 seekSet
     go dat'
   where go :: C'gpgme_data_t -> IO BS.ByteString
-        go dat = allocaBytes 1 $ \buf -> 
+        go dat = allocaBytes 1 $ \buf ->
                     do read_bytes <- c'gpgme_data_read dat buf 1
                        if read_bytes == 1
                           then do byte <- peek (castPtr buf)
@@ -42,7 +42,7 @@ checkError fun gpgme_err =
               srcstr <- c'gpgme_strsource gpgme_err
               src <- peekCString srcstr
               error ("Fun: " ++ fun ++
-                     ", Error: " ++ str ++ 
+                     ", Error: " ++ str ++
                      ", Source: " ++ show src)
 
 noError :: Num a => a
@@ -71,3 +71,13 @@ toValidity n
   | n == c'GPGME_VALIDITY_FULL      = ValidityFull
   | n == c'GPGME_VALIDITY_ULTIMATE  = ValidityUltimate
   | otherwise                       = error "validityFromInt: Unrecognized trust validity"
+
+toPubKeyAlgo :: C'gpgme_pubkey_algo_t -> PubKeyAlgo
+toPubKeyAlgo n
+  | n == c'GPGME_PK_RSA   = Rsa
+  | n == c'GPGME_PK_RSA_E = RsaE
+  | n == c'GPGME_PK_RSA_S = RsaS
+  | n == c'GPGME_PK_ELG_E = ElgE
+  | n == c'GPGME_PK_DSA   = Dsa
+  | n == c'GPGME_PK_ELG   = Elg
+  | otherwise             = error "toPubKeyAlgo: Unrecognized public key algorithm"

--- a/src/Crypto/Gpgme/Internal.hs
+++ b/src/Crypto/Gpgme/Internal.hs
@@ -61,3 +61,13 @@ fromSecret NoSecret   = 0
 fromFlag :: Flag -> CUInt
 fromFlag AlwaysTrust = c'GPGME_ENCRYPT_ALWAYS_TRUST
 fromFlag NoFlag      = 0
+
+toValidity :: C'gpgme_validity_t -> Validity
+toValidity n
+  | n == c'GPGME_VALIDITY_UNKNOWN   = ValidityUnknown
+  | n == c'GPGME_VALIDITY_UNDEFINED = ValidityUndefined
+  | n == c'GPGME_VALIDITY_NEVER     = ValidityNever
+  | n == c'GPGME_VALIDITY_MARGINAL  = ValidityMarginal
+  | n == c'GPGME_VALIDITY_FULL      = ValidityFull
+  | n == c'GPGME_VALIDITY_ULTIMATE  = ValidityUltimate
+  | otherwise                       = error "validityFromInt: Unrecognized trust validity"

--- a/src/Crypto/Gpgme/Key.hs
+++ b/src/Crypto/Gpgme/Key.hs
@@ -110,13 +110,9 @@ peekList nextFunc = go []
 
 keyUserIds' :: Key -> IO [KeyUserId]
 keyUserIds' key = withForeignPtr (unKey key) $ \keyPtr -> do
-    readUserIds keyPtr >>= mapM readKeyUserId
+    key' <- peek keyPtr >>= peek
+    peekList c'_gpgme_user_id'next (c'_gpgme_key'uids key') >>= mapM readKeyUserId
   where
-    readUserIds :: Ptr C'gpgme_key_t -> IO [C'_gpgme_user_id]
-    readUserIds keyPtr = do
-        key' <- peek keyPtr >>= peek
-        peekList c'_gpgme_user_id'next (c'_gpgme_key'uids key')
-
     readKeyUserId :: C'_gpgme_user_id -> IO KeyUserId
     readKeyUserId uid =
         KeyUserId <$> pure (toValidity $ c'_gpgme_user_id'validity uid)

--- a/src/Crypto/Gpgme/Key.hs
+++ b/src/Crypto/Gpgme/Key.hs
@@ -3,6 +3,7 @@ module Crypto.Gpgme.Key (
     , listKeys
       -- * Information about keys
     , Validity (..)
+    , PubKeyAlgo (..)
     , KeySignature (..)
     , UserId (..)
     , KeyUserId (..)

--- a/src/Crypto/Gpgme/Key.hs
+++ b/src/Crypto/Gpgme/Key.hs
@@ -2,6 +2,7 @@ module Crypto.Gpgme.Key (
       getKey
     , listKeys
       -- * Information about keys
+    , Validity (..)
     , KeySignature (..)
     , UserId (..)
     , KeyUserId (..)

--- a/src/Crypto/Gpgme/Key.hs
+++ b/src/Crypto/Gpgme/Key.hs
@@ -64,6 +64,11 @@ data KeySignature = KeySig { keysigAlgorithm :: PubKeyAlgo
                              -- TODO: Notations
                            }
 
+readTime :: CLong -> Maybe UTCTime
+readTime (-1) = Nothing
+readTime 0    = Nothing
+readTime t    = Just $ posixSecondsToUTCTime $ realToFrac t
+
 readKeySignatures :: C'gpgme_key_sig_t -> IO [KeySignature]
 readKeySignatures p0 = peekList c'_gpgme_key_sig'next p0 >>= mapM readSig
   where
@@ -74,11 +79,6 @@ readKeySignatures p0 = peekList c'_gpgme_key_sig'next p0 >>= mapM readSig
                <*> pure (readTime $ c'_gpgme_key_sig'expires sig)
                <*> signerId
       where
-        readTime :: CInt -> Maybe UTCTime
-        readTime (-1) = Nothing
-        readTime 0    = Nothing
-        readTime t    = Just $ posixSecondsToUTCTime $ realToFrac t
-
         signerId :: IO UserId
         signerId =
             UserId <$> peekCString (c'_gpgme_key_sig'uid sig)

--- a/src/Crypto/Gpgme/Key.hs
+++ b/src/Crypto/Gpgme/Key.hs
@@ -1,7 +1,6 @@
 module Crypto.Gpgme.Key (
       getKey
     , listKeys
-    , withKey
     ) where
 
 import Bindings.Gpgme
@@ -31,9 +30,7 @@ listKeys (Ctx ctxPtr _) secret = do
     go []
 
 -- | Returns a 'Key' from the @context@ based on its @fingerprint@.
---   As a 'Key' returned from the function needs to be freed
---   with 'freeKey', the use of 'withKey' is encouraged. Returns
---   Nothing if no 'Key' with this 'Fpr' exists.
+--   Returns 'Nothing' if no 'Key' with this 'Fpr' exists.
 getKey :: Ctx           -- ^ context to operate in
        -> Fpr           -- ^ fingerprint
        -> IncludeSecret -- ^ whether to include secrets when searching for the key
@@ -47,21 +44,3 @@ getKey (Ctx ctxPtr _) fpr secret = do
     if ret == noError
         then return . Just $ key
         else return Nothing
-
--- | Conveniently runs the @action@ with the 'Key' associated
---   with the 'Fpr' in the 'Ctx' and frees it afterwards.
---   If no 'Key' with this 'Fpr' exists, Nothing is returned.
-
-withKey :: Ctx           -- ^ context to operate in
-        -> Fpr           -- ^ fingerprint
-        -> IncludeSecret -- ^ whether to include secrets when searching for the key
-        -> (Key -> IO a) -- ^ action to be run with key
-        -> IO (Maybe a)
-withKey ctx fpr is f = do 
-    mbkey <- getKey ctx fpr is
-    case mbkey of
-        Just key -> do res <- f key
-                       return (Just res)
-        Nothing -> return Nothing
-
-

--- a/src/Crypto/Gpgme/Types.hs
+++ b/src/Crypto/Gpgme/Types.hs
@@ -78,3 +78,13 @@ data Validity = ValidityUnknown
               | ValidityMarginal
               | ValidityFull
               | ValidityUltimate
+
+-- | A public-key encryption algorithm
+data PubKeyAlgo =
+      Rsa
+    | RsaE
+    | RsaS
+    | ElgE
+    | Dsa
+    | Elg
+    deriving (Show, Ord, Eq)

--- a/src/Crypto/Gpgme/Types.hs
+++ b/src/Crypto/Gpgme/Types.hs
@@ -70,3 +70,11 @@ toDecryptError 58  = NoData
 toDecryptError 152 = Failed
 toDecryptError 11  = BadPass
 toDecryptError x   = Unknown (fromIntegral x)
+
+-- | The validity of a user identity
+data Validity = ValidityUnknown
+              | ValidityUndefined
+              | ValidityNever
+              | ValidityMarginal
+              | ValidityFull
+              | ValidityUltimate

--- a/src/Crypto/Gpgme/Types.hs
+++ b/src/Crypto/Gpgme/Types.hs
@@ -72,12 +72,14 @@ toDecryptError 11  = BadPass
 toDecryptError x   = Unknown (fromIntegral x)
 
 -- | The validity of a user identity
-data Validity = ValidityUnknown
-              | ValidityUndefined
-              | ValidityNever
-              | ValidityMarginal
-              | ValidityFull
-              | ValidityUltimate
+data Validity =
+      ValidityUnknown
+    | ValidityUndefined
+    | ValidityNever
+    | ValidityMarginal
+    | ValidityFull
+    | ValidityUltimate
+    deriving (Show, Ord, Eq)
 
 -- | A public-key encryption algorithm
 data PubKeyAlgo =

--- a/src/Crypto/Gpgme/Types.hs
+++ b/src/Crypto/Gpgme/Types.hs
@@ -32,7 +32,15 @@ type InvalidKey = (String, Int)
 -- TODO map intot better error code
 
 -- | A key from the context
-newtype Key = Key { unKey :: Ptr C'gpgme_key_t }
+newtype Key = Key { unKey :: ForeignPtr C'gpgme_key_t }
+
+-- | Allocate a key
+allocKey :: IO Key
+allocKey = Key `fmap` mallocForeignPtr
+
+-- | Perform an action with the pointer to a 'Key'
+withKeyPtr :: Key -> (Ptr C'gpgme_key_t -> IO a) -> IO a
+withKeyPtr (Key fPtr) f = withForeignPtr fPtr f
 
 -- | Whether to include secret keys when searching
 data IncludeSecret =

--- a/test/CryptoTest.hs
+++ b/test/CryptoTest.hs
@@ -1,6 +1,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 module CryptoTest (tests) where
 
+import Control.Monad (liftM)
+import Control.Monad.Trans.Maybe
 import Data.List (isInfixOf)
 import Data.ByteString.Char8 ()
 import qualified Data.ByteString as BS
@@ -27,6 +29,9 @@ tests = [ testProperty "bob_encrypt_for_alice_decrypt"
         , testCase "bob_encrypt_symmetrically" bob_encrypt_symmetrically
         ]
 
+hush :: Monad m => m (Either e a) -> MaybeT m a
+hush = MaybeT . liftM (either (const Nothing) Just)
+
 bob_encrypt_for_alice_decrypt :: Plain -> Property
 bob_encrypt_for_alice_decrypt plain =
     not (BS.null plain) ==> monadicIO $ do
@@ -36,13 +41,13 @@ bob_encrypt_for_alice_decrypt plain =
             do let alice_pub_fpr = "EAACEB8A"
 
                -- encrypt
-               enc <- withCtx "test/bob" "C" OpenPGP $ \bCtx ->
-                       withKey bCtx alice_pub_fpr NoSecret $ \aPubKey ->
-                           encrypt bCtx [aPubKey] NoFlag plain
+               Just enc <- withCtx "test/bob" "C" OpenPGP $ \bCtx -> runMaybeT $ do
+                       aPubKey <- MaybeT $ getKey bCtx alice_pub_fpr NoSecret
+                       hush $ encrypt bCtx [aPubKey] NoFlag plain
 
                -- decrypt
                dec <- withCtx "test/alice" "C" OpenPGP $ \aCtx ->
-                       decrypt aCtx (fromJustAndRight enc)
+                       decrypt aCtx enc
 
                return $ fromRight dec
 
@@ -71,13 +76,13 @@ bob_encrypt_sign_for_alice_decrypt_verify plain =
             do let alice_pub_fpr = "EAACEB8A"
 
                -- encrypt
-               enc <- withCtx "test/bob" "C" OpenPGP $ \bCtx ->
-                       withKey bCtx alice_pub_fpr NoSecret $ \aPubKey ->
-                           encryptSign bCtx [aPubKey] NoFlag plain
+               Just enc <- withCtx "test/bob" "C" OpenPGP $ \bCtx -> runMaybeT $ do
+                       aPubKey <- MaybeT $ getKey bCtx alice_pub_fpr NoSecret
+                       hush $ encryptSign bCtx [aPubKey] NoFlag plain
 
                -- decrypt
                dec <- withCtx "test/alice" "C" OpenPGP $ \aCtx ->
-                       decryptVerify aCtx (fromJustAndRight enc)
+                       decryptVerify aCtx enc
 
                return $ fromRight dec
 

--- a/test/KeyTest.hs
+++ b/test/KeyTest.hs
@@ -14,8 +14,10 @@ tests = [ testCase "get_alice_pub_from_alice" get_alice_pub_from_alice
         , testCase "alice_list_secret_keys" alice_list_secret_keys
         , testCase "get_inexistent_from_alice" get_inexistent_pub_from_alice
         , testCase "check_alice_pub_user_ids" check_alice_pub_user_ids
+        , testCase "check_alice_pub_subkeys" check_alice_pub_subkeys
         ]
 
+alice_pub_fpr, bob_pub_fpr :: Fpr
 alice_pub_fpr = "EAACEB8A"
 bob_pub_fpr = "6C4FB8F2"
 
@@ -66,3 +68,14 @@ check_alice_pub_user_ids = do
            userName uid @?= "Alice"
            userEmail uid @?= "alice@email.com"
            userComment uid @?= "Test User A"
+
+check_alice_pub_subkeys :: Assertion
+check_alice_pub_subkeys = do
+    withCtx "test/alice" "C" OpenPGP $ \ctx ->
+        do Just key <- getKey ctx alice_pub_fpr NoSecret
+           let subs = keySubKeys key
+           length subs @?= 2
+           let sub = head subs
+           subkeyAlgorithm sub @?= Rsa
+           subkeyLength sub @?= 2048
+           subkeyKeyId sub @?= "6B9809775CF91391"

--- a/test/KeyTest.hs
+++ b/test/KeyTest.hs
@@ -12,8 +12,6 @@ tests = [ testCase "get_alice_pub_from_alice" get_alice_pub_from_alice
         , testCase "alice_list_pub_keys" alice_list_pub_keys
         , testCase "alice_list_secret_keys" alice_list_secret_keys
         , testCase "get_inexistent_from_alice" get_inexistent_pub_from_alice
-        , testCase "with_inexistent_from_alice" with_inexistent_from_alice
-        , testCase "with_alice_pub_from_alice" with_alice_pub_from_alice
         ]
 
 get_alice_pub_from_alice :: Assertion
@@ -48,20 +46,3 @@ get_inexistent_pub_from_alice = do
     withCtx "test/alice/" "C" OpenPGP $ \ctx ->
         do key <- getKey ctx inexistent_fpr NoSecret
            isNothing key @? "existing " ++ show inexistent_fpr
-
-with_inexistent_from_alice :: Assertion
-with_inexistent_from_alice = do
-    let inexistent_fpr = "ABCDEF"
-    withCtx "test/alice/" "C" OpenPGP $ \ctx ->
-        do res <- withKey ctx inexistent_fpr NoSecret $ \_ -> do
-                    assertFailure "should not run action"
-           isNothing res @? "should be nothing"
-
-with_alice_pub_from_alice :: Assertion
-with_alice_pub_from_alice = do
-    let alice_pub_fpr = "EAACEB8A"
-    withCtx "test/alice/" "C" OpenPGP $ \ctx ->
-        do res <- withKey ctx alice_pub_fpr NoSecret $ \_ -> do
-                    return ("foo" :: String)
-           isJust res @? "should be just"
-           fromJust res @?= "foo"

--- a/test/KeyTest.hs
+++ b/test/KeyTest.hs
@@ -6,24 +6,27 @@ import Test.Framework.Providers.HUnit
 import Test.HUnit
 
 import Crypto.Gpgme
+import Crypto.Gpgme.Key
 
 tests = [ testCase "get_alice_pub_from_alice" get_alice_pub_from_alice
         , testCase "get_bob_pub_from_alice" get_bob_pub_from_alice
         , testCase "alice_list_pub_keys" alice_list_pub_keys
         , testCase "alice_list_secret_keys" alice_list_secret_keys
         , testCase "get_inexistent_from_alice" get_inexistent_pub_from_alice
+        , testCase "check_alice_pub_user_ids" check_alice_pub_user_ids
         ]
+
+alice_pub_fpr = "EAACEB8A"
+bob_pub_fpr = "6C4FB8F2"
 
 get_alice_pub_from_alice :: Assertion
 get_alice_pub_from_alice = do
-    let alice_pub_fpr = "EAACEB8A"
     withCtx "test/alice" "C" OpenPGP $ \ctx ->
         do key <- getKey ctx alice_pub_fpr NoSecret
            isJust key @? "missing " ++ show alice_pub_fpr
 
 get_bob_pub_from_alice :: Assertion
 get_bob_pub_from_alice = do
-    let bob_pub_fpr = "6C4FB8F2"
     withCtx "test/alice/" "C" OpenPGP $ \ctx ->
         do key <- getKey ctx bob_pub_fpr NoSecret
            isJust key @? "missing " ++ show bob_pub_fpr
@@ -33,6 +36,9 @@ alice_list_pub_keys = do
     withCtx "test/alice" "C" OpenPGP $ \ctx ->
         do keys <- listKeys ctx NoSecret
            length keys @?= 2
+           let keyIds = [["163EC68CCF3FBF8E","DD2469546C4FB8F2"],
+                         ["6B9809775CF91391","3BA69AA2EAACEB8A"]]
+           map (map subkeyKeyId . keySubKeys) keys @?= keyIds
 
 alice_list_secret_keys :: Assertion
 alice_list_secret_keys = do
@@ -46,3 +52,17 @@ get_inexistent_pub_from_alice = do
     withCtx "test/alice/" "C" OpenPGP $ \ctx ->
         do key <- getKey ctx inexistent_fpr NoSecret
            isNothing key @? "existing " ++ show inexistent_fpr
+
+check_alice_pub_user_ids :: Assertion
+check_alice_pub_user_ids = do
+    withCtx "test/alice" "C" OpenPGP $ \ctx ->
+        do Just key <- getKey ctx alice_pub_fpr NoSecret
+           let uids = keyUserIds key
+           length uids @?= 1
+           let kuid = head uids
+               uid = keyuserId kuid
+           keyuserValidity kuid @?= ValidityUltimate
+           userId uid @?= "Alice (Test User A) <alice@email.com>"
+           userName uid @?= "Alice"
+           userEmail uid @?= "alice@email.com"
+           userComment uid @?= "Test User A"

--- a/test/KeyTest.hs
+++ b/test/KeyTest.hs
@@ -22,7 +22,6 @@ get_alice_pub_from_alice = do
     withCtx "test/alice" "C" OpenPGP $ \ctx ->
         do key <- getKey ctx alice_pub_fpr NoSecret
            isJust key @? "missing " ++ show alice_pub_fpr
-           freeKey (fromJust key)
 
 get_bob_pub_from_alice :: Assertion
 get_bob_pub_from_alice = do
@@ -30,7 +29,6 @@ get_bob_pub_from_alice = do
     withCtx "test/alice/" "C" OpenPGP $ \ctx ->
         do key <- getKey ctx bob_pub_fpr NoSecret
            isJust key @? "missing " ++ show bob_pub_fpr
-           freeKey (fromJust key)
 
 alice_list_pub_keys :: Assertion
 alice_list_pub_keys = do


### PR DESCRIPTION
This depends upon #4.

This adds support for viewing information about keys. The approach attempts to hide the impurity of the foreign interface with `unsafePerformIO`, although this should be a safe usage as now the key lifecycle is managed by the garbage collector. It might be a good idea to replace all instances of `String` with `ByteString`.

This will require a bump in the lower bound for `bindings-dsl` due to https://github.com/jwiegley/bindings-dsl/pull/4