### PR TITLE
Revert "Add type annotations for test lists"

### DIFF
--- a/test/CryptoTest.hs
+++ b/test/CryptoTest.hs
@@ -4,7 +4,6 @@ module CryptoTest (tests) where
 import Data.List (isInfixOf)
 import Data.ByteString.Char8 ()
 import qualified Data.ByteString as BS
-import Test.Framework.Core (Test)
 import Test.Framework.Providers.HUnit
 import Test.Framework.Providers.QuickCheck2
 import Test.HUnit hiding (assert)
@@ -14,7 +13,6 @@ import Test.QuickCheck
 import Crypto.Gpgme
 import TestUtil
 
-tests :: [Test]
 tests = [ testProperty "bob_encrypt_for_alice_decrypt"
                        bob_encrypt_for_alice_decrypt
         , testProperty "bob_encrypt_sign_for_alice_decrypt_verify"

--- a/test/CtxTest.hs
+++ b/test/CtxTest.hs
@@ -1,12 +1,10 @@
 module CtxTest (tests) where
 
-import Test.Framework.Core (Test)
 import Test.Framework.Providers.HUnit
 import Test.HUnit
 
 import Crypto.Gpgme
 
-tests :: [Test]
 tests = [ testCase "run_action_with_ctx" run_action_with_ctx
         -- , testCase "unlock_with_pw" unlock_with_pw
         ]

--- a/test/KeyTest.hs
+++ b/test/KeyTest.hs
@@ -2,13 +2,11 @@
 module KeyTest (tests) where
 
 import Data.Maybe
-import Test.Framework.Core (Test)
 import Test.Framework.Providers.HUnit
 import Test.HUnit
 
 import Crypto.Gpgme
 
-tests :: [Test]
 tests = [ testCase "get_alice_pub_from_alice" get_alice_pub_from_alice
         , testCase "get_bob_pub_from_alice" get_bob_pub_from_alice
         , testCase "get_inexistent_from_alice" get_inexistent_pub_from_alice


### PR DESCRIPTION
Hi @bgamari, in my version of the package test-framework, the module Test.Framework.Core is hidden. This doesn't seem to have changed even with the most recent version on github. How did you get this to compile? 