### PR TITLE
Passphrase callbacks

### DIFF
--- a/src/Crypto/Gpgme.hs
+++ b/src/Crypto/Gpgme.hs
@@ -38,6 +38,9 @@ module Crypto.Gpgme (
     , freeCtx
     , withCtx
     , setArmor
+      -- ** Passphrase callbacks
+    , PassphraseCb
+    , setPassphraseCallback
 
     -- currently not exported as it does not work as expected:
     -- , withPWCtx

--- a/src/Crypto/Gpgme.hs
+++ b/src/Crypto/Gpgme.hs
@@ -69,7 +69,12 @@ module Crypto.Gpgme (
     , decryptVerify
     , decryptVerify'
 
-      -- * Other Types
+    -- * Error handling
+    , GpgmeError
+    , errorString
+    , sourceString
+
+    -- * Other Types
     , Fpr
     , Encrypted
     , Plain

--- a/src/Crypto/Gpgme.hs
+++ b/src/Crypto/Gpgme.hs
@@ -39,6 +39,7 @@ module Crypto.Gpgme (
     , withCtx
     , setArmor
       -- ** Passphrase callbacks
+    , isPassphraseCbSupported
     , PassphraseCb
     , setPassphraseCallback
 

--- a/src/Crypto/Gpgme/Crypto.hs
+++ b/src/Crypto/Gpgme/Crypto.hs
@@ -70,7 +70,7 @@ encryptIntern :: (C'gpgme_ctx_t
                   -> Flag
                   -> Plain
                   -> IO (Either [InvalidKey] Encrypted) 
-encryptIntern enc_op (Ctx ctxPtr _) recPtrs flag plain = do
+encryptIntern enc_op (Ctx {_ctx=ctxPtr}) recPtrs flag plain = do
     -- init buffer with plaintext
     plainBufPtr <- malloc
     BS.useAsCString plain $ \bs -> do
@@ -147,7 +147,7 @@ decryptIntern :: (C'gpgme_ctx_t
                   -> Ctx
                   -> Encrypted
                   -> IO (Either DecryptError Plain)
-decryptIntern dec_op (Ctx ctxPtr _) cipher = do
+decryptIntern dec_op (Ctx {_ctx=ctxPtr}) cipher = do
     -- init buffer with cipher
     cipherBufPtr <- malloc
     BS.useAsCString cipher $ \bs -> do

--- a/src/Crypto/Gpgme/Ctx.hs
+++ b/src/Crypto/Gpgme/Ctx.hs
@@ -1,6 +1,7 @@
 module Crypto.Gpgme.Ctx where
 
 import Bindings.Gpgme
+import Control.Monad (when)
 import Foreign
 import Foreign.C.String
 import Foreign.C.Types
@@ -22,7 +23,7 @@ newCtx homedir localeStr protocol =
        version <- c'gpgme_check_version nullPtr >>= peekCString
 
        -- create context
-       ctxPtr <- malloc 
+       ctxPtr <- malloc
        checkError "gpgme_new" =<< c'gpgme_new ctxPtr
 
        ctx <- peek ctxPtr
@@ -69,3 +70,54 @@ setArmor :: Bool -> Ctx -> IO ()
 setArmor armored (Ctx {_ctx = ctxPtr}) = do
     ctx <- peek ctxPtr
     c'gpgme_set_armor ctx (if armored then 1 else 0)
+
+-- | A callback invoked when the engine requires a passphrase to
+-- proceed. The callback should return @Just@ the requested passphrase,
+-- or @Nothing@ to cancel the operation.
+type PassphraseCb =
+       String     -- ^ user ID hint
+    -> String     -- ^ passphrase info
+    -> Bool       -- ^ @True@ if the previous attempt was bad
+    -> IO (Maybe String)
+
+-- | Construct a passphrase callback, handling reporting of the
+-- passphrase back to gpgme.
+passphraseCb :: PassphraseCb -> IO C'gpgme_passphrase_cb_t
+passphraseCb callback = do
+    let go _ hint info prev_bad fd = do
+            hint' <- peekCString hint
+            info' <- peekCString info
+            result <- callback hint' info' (prev_bad /= 0)
+            let phrase = maybe "" id result
+            err <- withCStringLen (phrase++"\n") $ \(s,len) ->
+                c'gpgme_io_writen fd (castPtr s) (fromIntegral len)
+            when (err /= 0) $ checkError "passphraseCb" (fromIntegral err)
+            return $ maybe errCanceled (const 0) result
+        errCanceled = 99 -- TODO: Use constant
+    mk'gpgme_passphrase_cb_t go
+
+-- | Set the callback invoked when a passphrase is required from the user.
+--
+-- Note that the operation of this feature is a bit inconsistent between
+-- GPG versions. GPG 1.4 using the @use-agent@ option and GPG >= 2.1 require
+-- that the @gpg-agent@ for the session has the @allow-loopback-pinentry@
+-- option enabled (this can be achieved by adding @allow-loopback-pinentry@
+-- to @gpg-agent.conf@. GPG versions between 2.0 and 2.1 do not support the
+-- @--pinentry-mode@ option necessary for this support.
+--
+-- See <http://lists.gnupg.org/pipermail/gnupg-devel/2013-February/027345.html>
+-- and the @gpgme-tool@ example included in the @gpgme@ tree for details.
+setPassphraseCallback :: Ctx                   -- ^ context
+                      -> Maybe PassphraseCb    -- ^ a callback, or Nothing to disable
+                      -> IO ()
+setPassphraseCallback (Ctx ctxPtr _) callback = do
+    ctx <- peek ctxPtr
+    let mode = case callback of
+                   Nothing -> c'GPGME_PINENTRY_MODE_DEFAULT
+                   Just _  -> c'GPGME_PINENTRY_MODE_LOOPBACK
+    -- With GPG 1.4 using the use-agent option and >= GPG 2.0 the passphrase
+    -- callback won't have an opportunity to execute unless the loopback
+    -- pinentry-mode is used
+    c'gpgme_set_pinentry_mode ctx mode >>= checkError "setPassphraseCallback"
+    cb <- maybe (return nullFunPtr) passphraseCb callback
+    c'gpgme_set_passphrase_cb ctx cb nullPtr

--- a/src/Crypto/Gpgme/Key.hs
+++ b/src/Crypto/Gpgme/Key.hs
@@ -28,7 +28,7 @@ import Crypto.Gpgme.Internal
 listKeys :: Ctx            -- ^ context to operate in
          -> IncludeSecret  -- ^ whether to include the secrets
          -> IO [Key]
-listKeys (Ctx ctxPtr _) secret = do
+listKeys (Ctx {_ctx=ctxPtr}) secret = do
     peek ctxPtr >>= \ctx ->
         c'gpgme_op_keylist_start ctx nullPtr (fromSecret secret) >>= checkError "listKeys"
     let eof = 16383
@@ -49,7 +49,7 @@ getKey :: Ctx           -- ^ context to operate in
        -> Fpr           -- ^ fingerprint
        -> IncludeSecret -- ^ whether to include secrets when searching for the key
        -> IO (Maybe Key)
-getKey (Ctx ctxPtr _) fpr secret = do
+getKey (Ctx {_ctx=ctxPtr}) fpr secret = do
     key <- allocKey
     ret <- BS.useAsCString fpr $ \cFpr ->
         peek ctxPtr >>= \ctx ->

--- a/src/Crypto/Gpgme/Types.hs
+++ b/src/Crypto/Gpgme/Types.hs
@@ -84,11 +84,13 @@ data DecryptError =
     | Unknown GpgmeError  -- ^ something else went wrong
     deriving (Eq, Show)
 
-toDecryptError :: C'gpgme_err_code_t -> DecryptError
-toDecryptError 58  = NoData
-toDecryptError 152 = Failed
-toDecryptError 11  = BadPass
-toDecryptError x   = Unknown (GpgmeError x)
+toDecryptError :: C'gpgme_error_t -> DecryptError
+toDecryptError n =
+    case unsafePerformIO $ c'gpgme_err_code n of
+        58   -> NoData
+        152  -> Failed
+        11   -> BadPass
+        x    -> Unknown (GpgmeError x)
 
 -- | The validity of a user identity
 data Validity =

--- a/src/Crypto/Gpgme/Types.hs
+++ b/src/Crypto/Gpgme/Types.hs
@@ -13,6 +13,7 @@ data Protocol =
     | GPGCONF
     | OpenPGP
     | UNKNOWN
+    deriving (Show, Eq, Ord)
 
 -- | Context to be passed around with operations. Use 'newCtx' or
 --   'withCtx' in order to obtain an instance.
@@ -54,10 +55,12 @@ withKeyPtr (Key fPtr) f = withForeignPtr fPtr f
 data IncludeSecret =
       WithSecret -- ^ do not include secret keys
     | NoSecret   -- ^ include secret keys
+    deriving (Show, Eq, Ord)
 
 data Flag =
       AlwaysTrust
     | NoFlag
+    deriving (Show, Eq, Ord)
 
 -- | A GPGME error.
 --
@@ -82,7 +85,7 @@ data DecryptError =
     | Failed              -- ^ not a valid cipher
     | BadPass             -- ^ passphrase for secret was wrong
     | Unknown GpgmeError  -- ^ something else went wrong
-    deriving (Eq, Show)
+    deriving (Show, Eq, Ord)
 
 toDecryptError :: C'gpgme_error_t -> DecryptError
 toDecryptError n =

--- a/src/Crypto/Gpgme/Types.hs
+++ b/src/Crypto/Gpgme/Types.hs
@@ -18,8 +18,10 @@ data Protocol =
 -- | Context to be passed around with operations. Use 'newCtx' or
 --   'withCtx' in order to obtain an instance.
 data Ctx = Ctx {
-      _ctx :: Ptr C'gpgme_ctx_t
-    , _version :: String
+      _ctx             :: Ptr C'gpgme_ctx_t -- ^ context
+    , _version         :: String            -- ^ GPGME version
+    , _protocol        :: Protocol          -- ^ context protocol
+    , _engineVersion   :: String            -- ^ engine version
 }
 
 -- | a fingerprint

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -7,8 +7,11 @@ import CtxTest
 import CryptoTest 
 
 main :: IO ()
-main = defaultMain $ testGroup "tests"
-    [ testGroup "key"    KeyTest.tests
-    , testGroup "ctx"    CtxTest.tests
-    , testGroup "crypto" CryptoTest.tests
-    ]
+main = do
+    passphraseCbTests <- CryptoTest.cbTests
+    defaultMain $ testGroup "tests"
+        [ testGroup "key"    KeyTest.tests
+        , testGroup "ctx"    CtxTest.tests
+        , CryptoTest.tests
+        , passphraseCbTests
+        ]

--- a/test/alice/gpg-agent.conf
+++ b/test/alice/gpg-agent.conf
@@ -1,0 +1,1 @@
+allow-loopback-pinentry

--- a/test/bob/gpg-agent.conf
+++ b/test/bob/gpg-agent.conf
@@ -1,0 +1,1 @@
+allow-loopback-pinentry


### PR DESCRIPTION
This adds support for passphrase callbacks. This requires the `--pinentry-mode` gpg option added in gpg 2.1. This has been tested with gpg 2.1.1 and gpgme 1.4.3. It seems fairly clear that this functionality will not work with the gpg 2.0 series due to the lack of the `--pinentry-mode` option. This will also be broken for gpg 1.4 users using `gpg-agent` for similar reasons.