### PR TITLE
Streamline 'runtests' script

### DIFF
--- a/runtests
+++ b/runtests
@@ -7,4 +7,12 @@ echo "Bob's passphrase: \`bob123\`"
 echo "Alice's passphrase: \`alice123\`"
 echo "Use any password for symmetrical encryption test"
 
-stack test
+# Remove this annoying file if it already exists
+rm -f tests.tix
+
+if [ -z "$@" ]; then
+  stack test
+else
+  echo "Running with the test arguments '-p $@'"
+  stack test --test-arguments "-p $@"
+fi


### PR DESCRIPTION
- Allow developer to be able to more quickly run tests they are interested
in by specifying a string as a parameter to 'runtests'
- Remove the 'tests.tix' on start of 'runtests' script