### PR TITLE
Fix `verifyInternal` function to prevent crash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,11 +10,13 @@
 - Add clear sign functionality
 - Add progress callback functionality
 - Add file encryption and decryption
+- Add safe `collectSignatures'` function
 
 ### Bug fixes
 
 - Prevent potential memory leak in `withCtx`
 - Return full fingerprint for `keySubKeys`
+- Fix crash bug in `verifyInternal` involving a call to `performUnsafeIO`
 
 ## 0.4.0.0
 - verifyDetached and verifyDetached' Verify a payload using a detached signature. (thanks mmhat)

--- a/src/Crypto/Gpgme.hs
+++ b/src/Crypto/Gpgme.hs
@@ -81,7 +81,7 @@ module Crypto.Gpgme (
     , decryptVerify'
     , verifyDetached
     , verifyDetached'
-    , clearSign
+    , sign
     , verifyPlain
     , verifyPlain'
 

--- a/src/Crypto/Gpgme/Internal.hs
+++ b/src/Crypto/Gpgme/Internal.hs
@@ -34,8 +34,13 @@ collectResult dat' = unsafePerformIO $ do
                           else return BS.empty
         seekSet = 0
 
+-- ^ Unsafe IO version of `collectSignatures`. Try to use `collectSignatures'` instead.
 collectSignatures :: C'gpgme_ctx_t -> VerificationResult
-collectSignatures ctx = unsafePerformIO $ do
+collectSignatures ctx = unsafePerformIO $ collectSignatures' ctx
+
+-- ^ Return signatures a GPG verify action.
+collectSignatures' :: C'gpgme_ctx_t -> IO VerificationResult
+collectSignatures' ctx = do
     verify_res <- c'gpgme_op_verify_result ctx
     sigs <- peek $ p'_gpgme_op_verify_result'signatures verify_res
     go sigs

--- a/src/Crypto/Gpgme/Types.hs
+++ b/src/Crypto/Gpgme/Types.hs
@@ -26,6 +26,8 @@ data Ctx = Ctx {
     , _engineVersion   :: String            -- ^ engine version
 }
 
+data SignMode = Normal | Detach | Clear deriving Show
+
 -- | a fingerprint
 type Fpr = BS.ByteString
 


### PR DESCRIPTION
- Add tests to detect crashes in `verifyInternal`
- Create general `sign` function for Normal, Detach and Clear sign modes
- Create safe `collectSignature'` function