### PR TITLE
Fix build failure due to insufficiently strict version bound.

### DIFF
--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -3,7 +3,10 @@ FROM haskell
 MAINTAINER David Parrish <daveparrish@tutanota.com>
 
 RUN apt-get update \
- && apt-get install -y --no-install-recommends libgpgme11-dev
+ && apt-get install -y --no-install-recommends \
+ xz \
+ make \
+ libgpgme11-dev
 
 WORKDIR /root/build
 CMD stack setup \

--- a/h-gpgme.cabal
+++ b/h-gpgme.cabal
@@ -33,7 +33,7 @@ library
   build-depends:       base           == 4.*
                      , bindings-gpgme >= 0.1.6 && <0.2
                      , bytestring     >= 0.9
-                     , either         >= 4.3 && <5.0
+                     , either         >= 4.3 && <5
                      , time           >= 1.4 && <2.0
                      , unix           >= 2.5
                      , email-validate
@@ -51,7 +51,7 @@ test-suite tests
   build-depends:       base           == 4.*
                      , bindings-gpgme >= 0.1.6 && <0.2
                      , bytestring     >= 0.9
-                     , either         >= 4.3 && <5.0
+                     , either         >= 4.3 && <5
                      , transformers   >= 0.3 && <0.6
                      , time           >= 1.4 && <2.0
                      , unix           >= 2.5


### PR DESCRIPTION
See the commit message. I don't know how signficant the changes between the latest release and master are; it may or may not make sense to also cherry-pick this for a patch release to fix the builds.

It might also be sensible to chop of other `.0`s in upper bounds, but this is the minimum required currently to fix the build.