### PR TITLE
Implemented key listing modes

### DIFF
--- a/src/Crypto/Gpgme.hs
+++ b/src/Crypto/Gpgme.hs
@@ -38,6 +38,7 @@ module Crypto.Gpgme (
     , freeCtx
     , withCtx
     , setArmor
+    , setKeyListingMode
       -- ** Passphrase callbacks
     , isPassphraseCbSupported
     , PassphraseCb
@@ -93,6 +94,7 @@ module Crypto.Gpgme (
     , sourceString
 
     -- * Other Types
+    , KeyListingMode(..)
     , SignMode(..)
 
     , Fpr

--- a/src/Crypto/Gpgme/Ctx.hs
+++ b/src/Crypto/Gpgme/Ctx.hs
@@ -87,6 +87,13 @@ setArmor armored (Ctx {_ctx = ctxPtr}) = do
     ctx <- peek ctxPtr
     c'gpgme_set_armor ctx (if armored then 1 else 0)
 
+-- | Sets the key listing mode on ctx
+setKeyListingMode :: [KeyListingMode] -> Ctx -> IO ()
+setKeyListingMode modes (Ctx {_ctx = ctxPtr}) = do
+    let m = foldl (\memo -> (memo .|.) . fromKeyListingMode) 0 modes
+    ctx <- peek ctxPtr
+    checkError "set_keylist_mode" =<< c'gpgme_set_keylist_mode ctx m
+
 -- | Are passphrase callbacks supported?
 --
 -- This functionality is known to be broken in some gpg versions,

--- a/src/Crypto/Gpgme/Internal.hs
+++ b/src/Crypto/Gpgme/Internal.hs
@@ -68,6 +68,14 @@ checkError fun gpgme_err =
 noError :: Num a => a
 noError = 0
 
+fromKeyListingMode :: KeyListingMode -> C'gpgme_keylist_mode_t
+fromKeyListingMode KeyListingLocal        = c'GPGME_KEYLIST_MODE_LOCAL
+fromKeyListingMode KeyListingExtern       = c'GPGME_KEYLIST_MODE_EXTERN
+fromKeyListingMode KeyListingSigs         = c'GPGME_KEYLIST_MODE_SIGS
+fromKeyListingMode KeyListingSigNotations = c'GPGME_KEYLIST_MODE_SIG_NOTATIONS
+fromKeyListingMode KeyListingValidate     = c'GPGME_KEYLIST_MODE_VALIDATE
+
+
 fromProtocol :: (Num a) => Protocol -> a
 fromProtocol CMS     =  c'GPGME_PROTOCOL_CMS
 fromProtocol GPGCONF =  c'GPGME_PROTOCOL_GPGCONF

--- a/src/Crypto/Gpgme/Types.hs
+++ b/src/Crypto/Gpgme/Types.hs
@@ -26,6 +26,14 @@ data Ctx = Ctx {
     , _engineVersion   :: String            -- ^ engine version
 }
 
+-- | Modes for key listings
+data KeyListingMode
+    = KeyListingLocal
+    | KeyListingExtern
+    | KeyListingSigs
+    | KeyListingSigNotations
+    | KeyListingValidate
+
 -- | Modes for signing with GPG
 data SignMode = Normal | Detach | Clear deriving Show
 


### PR DESCRIPTION
We were not able to retrieve a keys signatures due to the default key listing mode.
This PR adds support for key listing modes. Have a look at the two test cases: "set_listing_mode" and "no_set_listing_mode".
See [Key Listing Mode](https://www.gnupg.org/documentation/manuals/gpgme/Key-Listing-Mode.html)