### PR TITLE
feat: add force flag to removeKey function

### DIFF
--- a/h-gpgme.cabal
+++ b/h-gpgme.cabal
@@ -35,7 +35,7 @@ library
                      , Crypto.Gpgme.Internal
                      , Crypto.Gpgme.Types
   build-depends:       base           == 4.*
-                     , bindings-gpgme >= 0.1.6 && <0.2
+                     , bindings-gpgme >= 0.1.8 && <0.2
                      , bytestring     >= 0.9
                      , transformers   >= 0.4.1 && <0.6
                      , time           >= 1.4 && <2.0

--- a/src/Crypto/Gpgme.hs
+++ b/src/Crypto/Gpgme.hs
@@ -52,6 +52,8 @@ module Crypto.Gpgme (
     , getKey
     , listKeys
     , removeKey
+    , RemoveKeyFlags(..)
+
     -- * Information about keys
     , Validity (..)
     , PubKeyAlgo (..)

--- a/src/Crypto/Gpgme/Key.hs
+++ b/src/Crypto/Gpgme/Key.hs
@@ -64,21 +64,19 @@ getKey Ctx {_ctx=ctxPtr} fpr secret = do
 -- | Removes the 'Key' from @context@
 removeKey :: Ctx                    -- ^ context to operate in
           -> Key                    -- ^ key to delete
-          -> IncludeSecret          -- ^ include secret keys for deleting
+          -> RemoveKeyFlags         -- ^ flags for remove operation
           -> IO (Maybe GpgmeError)
 removeKey Ctx {_ctx=ctxPtr} key secret = do
   ctx <- peek ctxPtr
   ret <- withKeyPtr key (\keyPtr -> do
     k <- peek keyPtr
-    c'gpgme_op_delete ctx k s)
+    c'gpgme_op_delete_ext ctx k cFlags)
   if ret == 0
     then return Nothing
     else return $ Just $ GpgmeError ret
   where
-    s = secretToCInt secret
-    secretToCInt :: IncludeSecret -> CInt
-    secretToCInt WithSecret = 1
-    secretToCInt NoSecret   = 0
+    cFlags = (if allowSecret flags then 1 else 0) .|. (if force flags then 2 else 0)
+
 
 -- | A key signature
 data KeySignature = KeySig { keysigAlgorithm :: PubKeyAlgo

--- a/src/Crypto/Gpgme/Key.hs
+++ b/src/Crypto/Gpgme/Key.hs
@@ -66,7 +66,7 @@ removeKey :: Ctx                    -- ^ context to operate in
           -> Key                    -- ^ key to delete
           -> RemoveKeyFlags         -- ^ flags for remove operation
           -> IO (Maybe GpgmeError)
-removeKey Ctx {_ctx=ctxPtr} key secret = do
+removeKey Ctx {_ctx=ctxPtr} key flags = do
   ctx <- peek ctxPtr
   ret <- withKeyPtr key (\keyPtr -> do
     k <- peek keyPtr

--- a/src/Crypto/Gpgme/Types.hs
+++ b/src/Crypto/Gpgme/Types.hs
@@ -170,3 +170,9 @@ data PubKeyAlgo =
 -- | h-gpgme exception for wrapping exception which occur outside of the control of h-gpgme
 newtype HgpgmeException = HgpgmeException SomeException deriving (Show)
 instance Exception HgpgmeException
+
+-- | Flags for removeKey function
+data RemoveKeyFlags = RemoveKeyFlags {
+      allowSecret :: Bool -- ^ if False, only public keys are removed, otherwise secret keys are removed as well
+    , force       :: Bool -- ^ if True, don't ask for confirmation
+    } deriving (Show, Eq, Ord)

--- a/stack.yaml
+++ b/stack.yaml
@@ -46,11 +46,7 @@ packages:
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps:
-  - github: rethab/bindings-dsl
-    commit: 70c503ef67f0898c0f131e8ed83e334d688007a0
-    subdirs:
-      - bindings-gpgme
+extra-deps: [bindings-gpgme-0.1.8]
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml
+++ b/stack.yaml
@@ -46,7 +46,11 @@ packages:
 
 # Dependency packages to be pulled from upstream that are not in the resolver
 # (e.g., acme-missiles-0.3)
-extra-deps: [bindings-gpgme-0.1.7]
+extra-deps:
+  - github: rethab/bindings-dsl
+    commit: 70c503ef67f0898c0f131e8ed83e334d688007a0
+    subdirs:
+      - bindings-gpgme
 
 # Override default flag values for local packages and extra-deps
 flags: {}

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,15 +5,21 @@
 
 packages:
 - completed:
-    hackage: bindings-gpgme-0.1.7@sha256:b486a4a93e614111b637c6ff7e719c19f3f7d921cbf50930e112e3948246e688,1009
+    sha256: fa73d045f11efeca31726d310c90fc34acdfe5c21040361c271547336ddc91dd
+    name: bindings-gpgme
+    subdir: bindings-gpgme
+    size: 159528
+    url: https://github.com/rethab/bindings-dsl/archive/70c503ef67f0898c0f131e8ed83e334d688007a0.tar.gz
     pantry-tree:
-      size: 275
-      sha256: ba3a7ad409c63b71653cd993a2eb040ad2412963db5a9e131a5f7cb3f6afde7b
+      sha256: bdab8fb31add2060053476134e248ff9ec1bccb76ed60a9472f4671a4eaf08c6
+      size: 326
+    version: 0.1.7
   original:
-    hackage: bindings-gpgme-0.1.7
+    subdir: bindings-gpgme
+    url: https://github.com/rethab/bindings-dsl/archive/70c503ef67f0898c0f131e8ed83e334d688007a0.tar.gz
 snapshots:
 - completed:
+    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
     size: 590100
     url: https://raw.githubusercontent.com/commercialhaskell/stackage-snapshots/master/lts/18/28.yaml
-    sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68
   original: lts-18.28

--- a/stack.yaml.lock
+++ b/stack.yaml.lock
@@ -5,18 +5,12 @@
 
 packages:
 - completed:
-    sha256: fa73d045f11efeca31726d310c90fc34acdfe5c21040361c271547336ddc91dd
-    name: bindings-gpgme
-    subdir: bindings-gpgme
-    size: 159528
-    url: https://github.com/rethab/bindings-dsl/archive/70c503ef67f0898c0f131e8ed83e334d688007a0.tar.gz
     pantry-tree:
-      sha256: bdab8fb31add2060053476134e248ff9ec1bccb76ed60a9472f4671a4eaf08c6
-      size: 326
-    version: 0.1.7
+      sha256: f1445c8b869d022d2ea9019624b095775b60e2d4282097bf5b7ffaf752518d85
+      size: 275
+    hackage: bindings-gpgme-0.1.8@sha256:91ce499f1fd03129663f52dfbebd843502aba77e2c52e1da44f976db64ca2fc3,1114
   original:
-    subdir: bindings-gpgme
-    url: https://github.com/rethab/bindings-dsl/archive/70c503ef67f0898c0f131e8ed83e334d688007a0.tar.gz
+    hackage: bindings-gpgme-0.1.8
 snapshots:
 - completed:
     sha256: 428ec8d5ce932190d3cbe266b9eb3c175cd81e984babf876b64019e2cbe4ea68

--- a/test/KeyTest.hs
+++ b/test/KeyTest.hs
@@ -25,7 +25,7 @@ tests = [ testCase "getAlicePubFromAlice" getAlicePubFromAlice
         , testCase "getInexistentFromAlice" getInexistentPubFromAlice
         , testCase "checkAlicePubUserIds" checkAlicePubUserIds
         , testCase "checkAlicePubSubkeys" checkAlicePubSubkeys
-        , testCase "removeAliceKeyPromptNoCi" removeAliceKey
+        , testCase "removeAliceKey" removeAliceKey
         ]
 
 getAlicePubFromAlice :: Assertion
@@ -107,7 +107,7 @@ removeAliceKey = do
     do key <- getKey ctx alicePubFpr WithSecret
        startNum <- listKeys ctx WithSecret >>= \l -> return $ length l
        startNum @?= 1
-       ret <- removeKey ctx (fromJust key) WithSecret
+       ret <- removeKey ctx (fromJust key) (RemoveKeyFlags True True)
        endNum <- listKeys ctx WithSecret >>= \l -> return $ length l
        endNum @?= 0
        ret @?= Nothing


### PR DESCRIPTION
* BREAKING CHANGE: the function `removeKey` takes a new argument `RemoveKeyFlags` instead of `IncludeSecrets`. This is to support the "new" gpgme_ext function, which allows to pass more arguments.

Closes: https://github.com/rethab/h-gpgme/issues/41

