### PR TITLE
feat: copy more than 1 byte at a time from gpgme_data

### DIFF
--- a/src/Crypto/Gpgme/Internal.hs
+++ b/src/Crypto/Gpgme/Internal.hs
@@ -3,7 +3,10 @@ module Crypto.Gpgme.Internal where
 import Bindings.Gpgme
 import Control.Monad (unless)
 import qualified Data.ByteString as BS
-import Foreign (allocaBytes, castPtr, nullPtr, peek, Ptr, malloc)
+import qualified Data.ByteString.Internal as BS (createAndTrim)
+import qualified Data.ByteString.Lazy as LBS
+import qualified Data.ByteString.Lazy.Internal as LBS (defaultChunkSize)
+import Foreign (castPtr, nullPtr, peek, Ptr, malloc)
 import Foreign.C.String (peekCString)
 import Foreign.C.Types (CUInt, CInt)
 import System.IO.Unsafe (unsafePerformIO)
@@ -19,20 +22,35 @@ collectFprs result = unsafePerformIO $ peek result >>= go
             rest <- go (c'_gpgme_invalid_key'next invalid)
             return ((fpr, reason) : rest)
 
+-- | Read the buffer into a ByteString.
+--
+-- Chunks of Data.ByteString.Lazy.Internal.defaultChunkSize are allocated and
+-- copied, until the gpgme_data_readbuffer read returns less than this.
+-- Then the list of chunks are copied into a strict ByteString by way of a lazy
+-- ByteString.
 collectResult :: C'gpgme_data_t -> BS.ByteString
 collectResult dat' = unsafePerformIO $ do
     -- make sure we start at the beginning
     _ <- c'gpgme_data_seek dat' 0 seekSet
-    go dat'
-  where go :: C'gpgme_data_t -> IO BS.ByteString
-        go dat = allocaBytes 1 $ \buf ->
-                    do read_bytes <- c'gpgme_data_read dat buf 1
-                       if read_bytes == 1
-                          then do byte <- peek (castPtr buf)
-                                  rest <- go dat
-                                  return (byte `BS.cons` rest)
-                          else return BS.empty
+    chunks <- go dat'
+    pure $ LBS.toStrict (LBS.fromChunks chunks)
+  where makeChunk :: C'gpgme_data_t -> IO BS.ByteString
+        makeChunk dat = BS.createAndTrim chunkSize $ \buf -> do
+          -- createAndTrim gives a Ptr Word8 but the gpgme functions wants a Ptr ()
+          read_bytes <- c'gpgme_data_read dat (castPtr buf) (fromIntegral chunkSize)
+          pure $ fromIntegral read_bytes
+
+        go :: C'gpgme_data_t -> IO [BS.ByteString]
+        go dat = do
+          bs <- makeChunk dat
+          if BS.length bs < chunkSize
+          then pure [bs]
+          else do
+            bss <- go dat
+            pure (bs : bss)
+
         seekSet = 0
+        chunkSize = LBS.defaultChunkSize
 
 -- ^ Unsafe IO version of `collectSignatures`. Try to use `collectSignatures'` instead.
 collectSignatures :: C'gpgme_ctx_t -> VerificationResult


### PR DESCRIPTION
Previous implementation was very slow. This one does better by allocating and copying the defaultChunkSize for each chunk of the gpgme buffer.