### PR TITLE
Fix reversed doc comments on IncludeSecret

### DIFF
--- a/src/Crypto/Gpgme/Key.hs
+++ b/src/Crypto/Gpgme/Key.hs
@@ -32,13 +32,13 @@ import Crypto.Gpgme.Internal
 
 -- | Returns a list of all known 'Key's from the @context@.
 listKeys :: Ctx            -- ^ context to operate in
-         -> IncludeSecret  -- ^ whether to include the secrets
+         -> IncludeSecret  -- ^ whether to restrict to secret keys
          -> IO [Key]
 listKeys ctx secret = listKeys' ctx secret nullPtr
 
 -- | Returns a list of known 'Key's from the @context@ that match a given pattern.
 searchKeys :: Ctx            -- ^ context to operate in
-           -> IncludeSecret  -- ^ whether to include the secrets
+           -> IncludeSecret  -- ^ whether to restrict to secret keys
            -> String         -- ^ The pattern to look for; It is typically
                              -- matched against the user ids of a key.
            -> IO [Key]
@@ -46,7 +46,7 @@ searchKeys ctx secret pat = BS.useAsCString (BSC8.pack pat) (listKeys' ctx secre
 
 -- | Internal helper function used by both `listKeys` and `searchKeys`.
 listKeys' :: Ctx            -- ^ context to operate in
-          -> IncludeSecret  -- ^ whether to include the secrets
+          -> IncludeSecret  -- ^ whether to restrict to secret keys
           -> CString        -- ^ The pattern to look for; It is typically
                             -- matched against the user ids of a key.
           -> IO [Key]
@@ -69,7 +69,7 @@ listKeys' Ctx {_ctx=ctxPtr} secret pat = do
 --   Returns 'Nothing' if no 'Key' with this 'Fpr' exists.
 getKey :: Ctx           -- ^ context to operate in
        -> Fpr           -- ^ fingerprint
-       -> IncludeSecret -- ^ whether to include secrets when searching for the key
+       -> IncludeSecret -- ^ whether to look for a secret key
        -> IO (Maybe Key)
 getKey Ctx {_ctx=ctxPtr} fpr secret = do
     key <- allocKey

--- a/src/Crypto/Gpgme/Types.hs
+++ b/src/Crypto/Gpgme/Types.hs
@@ -103,10 +103,10 @@ allocKey = do
 withKeyPtr :: Key -> (Ptr C'gpgme_key_t -> IO a) -> IO a
 withKeyPtr (Key fPtr) = withForeignPtr fPtr
 
--- | Whether to include secret keys when searching
+-- | Whether to restrict an operation to secret keys
 data IncludeSecret =
-      WithSecret -- ^ do not include secret keys
-    | NoSecret   -- ^ include secret keys
+      WithSecret -- ^ only consider secret keys
+    | NoSecret   -- ^ do not consider secret keys
     deriving (Show, Eq, Ord)
 
 data Flag =


### PR DESCRIPTION
The Haddocks on `WithSecret` and `NoSecret` stated the opposite of what the constructors do. `fromSecret` maps `WithSecret` to `1`, which gpgme interprets as *secret-only* (`secret_only` in `gpgme_op_keylist_start`, `secret` in `gpgme_get_key`), so `WithSecret` restricts an operation to secret keys and `NoSecret` does not. Anyone reading the docs to pick a constructor would have picked the wrong one.

While here, the parameter Haddocks in `Key.hs` said "whether to include the secrets", which is misleading for the same reason: the flag narrows the search to secret keys rather than adding them to the result.

Fixes #62