### PR TITLE
Fix segfaults from NULL gpgme results and broken invalid-key list walk

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,5 +1,13 @@
 # Changelog
 
+## Unreleased
+
+### Bug fixes
+
+- fix: segfault in verify, verifyDetached and verifyPlain when the verify operation fails before gpgme produces a result (e.g. invalid homedir), as gpgme_op_verify_result returns NULL in that case (https://stackoverflow.com/questions/48908274)
+- fix: infinite recursion in collectFprs when encrypt or sign reports invalid keys
+- fix: segfault in newCtx when the gpg engine is not installed and its version is NULL
+
 ## 0.6.3.0
 
 ### New Features

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,7 +1,1 @@
 ignore-project: False
-package bindings-gpgme
-  extra-include-dirs: /opt/homebrew/opt/gpgme/include /opt/homebrew/opt/libassuan/include /opt/homebrew/opt/libgpg-error/include
-  extra-lib-dirs: /opt/homebrew/opt/gpgme/lib /opt/homebrew/opt/libassuan/lib /opt/homebrew/opt/libgpg-error/lib
-package h-gpgme
-  extra-include-dirs: /opt/homebrew/opt/gpgme/include
-  extra-lib-dirs: /opt/homebrew/opt/gpgme/lib

--- a/cabal.project.local
+++ b/cabal.project.local
@@ -1,1 +1,7 @@
 ignore-project: False
+package bindings-gpgme
+  extra-include-dirs: /opt/homebrew/opt/gpgme/include /opt/homebrew/opt/libassuan/include /opt/homebrew/opt/libgpg-error/include
+  extra-lib-dirs: /opt/homebrew/opt/gpgme/lib /opt/homebrew/opt/libassuan/lib /opt/homebrew/opt/libgpg-error/lib
+package h-gpgme
+  extra-include-dirs: /opt/homebrew/opt/gpgme/include
+  extra-lib-dirs: /opt/homebrew/opt/gpgme/lib

--- a/h-gpgme.cabal
+++ b/h-gpgme.cabal
@@ -82,6 +82,7 @@ test-suite tests
                      , Crypto.Gpgme.Types
                      , CryptoTest
                      , CtxTest
+                     , InternalTest
                      , KeyTest
                      , KeyGenTest
                      , TestUtil

--- a/src/Crypto/Gpgme/Crypto.hs
+++ b/src/Crypto/Gpgme/Crypto.hs
@@ -442,8 +442,6 @@ verifyInternal ver_op Ctx {_ctx=ctxPtr} sig dat = do
     -- verify
     (errcode, res) <- ver_op ctx sigBuf datBuf
 
-    -- the result of gpgme_op_verify_result is only valid
-    -- if the operation finished successfully
     res' <- if errcode /= noError
                 then return (Left (GpgmeError errcode))
                 else do sigs <- collectSignatures' ctx

--- a/src/Crypto/Gpgme/Crypto.hs
+++ b/src/Crypto/Gpgme/Crypto.hs
@@ -442,10 +442,12 @@ verifyInternal ver_op Ctx {_ctx=ctxPtr} sig dat = do
     -- verify
     (errcode, res) <- ver_op ctx sigBuf datBuf
 
-    sigs <- collectSignatures' ctx
-    let res' = if errcode /= noError
-                then Left  (GpgmeError errcode)
-                else Right (sigs, res)
+    -- the result of gpgme_op_verify_result is only valid
+    -- if the operation finished successfully
+    res' <- if errcode /= noError
+                then return (Left (GpgmeError errcode))
+                else do sigs <- collectSignatures' ctx
+                        return (Right (sigs, res))
 
     free sigBufPtr
     free datBufPtr

--- a/src/Crypto/Gpgme/Ctx.hs
+++ b/src/Crypto/Gpgme/Ctx.hs
@@ -31,9 +31,15 @@ newCtx homedir localeStr protocol =
 
        ctx <- peek ctxPtr
 
-       -- find engine version
-       engInfo <- c'gpgme_ctx_get_engine_info ctx >>= peek
-       engVersion <- peekCString $ c'_gpgme_engine_info'version engInfo
+       -- find engine version; the version field is NULL when the
+       -- engine binary is not installed or its version is unknown
+       engInfoPtr <- c'gpgme_ctx_get_engine_info ctx
+       engVersion <- if engInfoPtr == nullPtr
+                        then return ""
+                        else do verPtr <- peek (p'_gpgme_engine_info'version engInfoPtr)
+                                if verPtr == nullPtr
+                                   then return ""
+                                   else peekCString verPtr
 
        -- set locale
        locale <- newCString localeStr

--- a/src/Crypto/Gpgme/Ctx.hs
+++ b/src/Crypto/Gpgme/Ctx.hs
@@ -31,8 +31,7 @@ newCtx homedir localeStr protocol =
 
        ctx <- peek ctxPtr
 
-       -- find engine version; the version field is NULL when the
-       -- engine binary is not installed or its version is unknown
+       -- the version field is NULL when the engine binary is not installed
        engInfoPtr <- c'gpgme_ctx_get_engine_info ctx
        engVersion <- if engInfoPtr == nullPtr
                         then return ""

--- a/src/Crypto/Gpgme/Internal.hs
+++ b/src/Crypto/Gpgme/Internal.hs
@@ -13,13 +13,19 @@ import System.IO.Unsafe (unsafePerformIO)
 
 import Crypto.Gpgme.Types
 
+-- The struct is read field by field via the p' accessors: peeking a whole
+-- C'_gpgme_invalid_key diverges because its Storable instance recursively
+-- peeks the mistyped @next@ field.
 collectFprs :: C'gpgme_invalid_key_t -> [InvalidKey]
-collectFprs result = unsafePerformIO $ peek result >>= go
-    where go :: C'_gpgme_invalid_key -> IO [InvalidKey]
-          go invalid = do
-            fpr <- peekCString (c'_gpgme_invalid_key'fpr invalid)
-            let reason = fromIntegral (c'_gpgme_invalid_key'reason invalid)
-            rest <- go (c'_gpgme_invalid_key'next invalid)
+collectFprs = unsafePerformIO . go
+    where go :: C'gpgme_invalid_key_t -> IO [InvalidKey]
+          go ptr | ptr == nullPtr = return []
+          go ptr = do
+            fprPtr <- peek (p'_gpgme_invalid_key'fpr ptr)
+            fpr <- if fprPtr == nullPtr then return "" else peekCString fprPtr
+            reason <- fromIntegral `fmap` peek (p'_gpgme_invalid_key'reason ptr)
+            next <- peek (castPtr (p'_gpgme_invalid_key'next ptr) :: Ptr C'gpgme_invalid_key_t)
+            rest <- go next
             return ((fpr, reason) : rest)
 
 -- | Read the buffer into a ByteString.
@@ -60,14 +66,19 @@ collectSignatures ctx = unsafePerformIO $ collectSignatures' ctx
 collectSignatures' :: C'gpgme_ctx_t -> IO VerificationResult
 collectSignatures' ctx = do
     verify_res <- c'gpgme_op_verify_result ctx
-    sigs <- peek $ p'_gpgme_op_verify_result'signatures verify_res
-    go sigs
+    -- gpgme_op_verify_result returns NULL if the last operation on the
+    -- context was not a successful verify (e.g. it failed to even start
+    -- because of a bad homedir or missing engine)
+    if verify_res == nullPtr
+        then return []
+        else go =<< peek (p'_gpgme_op_verify_result'signatures verify_res)
     where
         go sig | sig == nullPtr = return []
         go sig = do
             status <- peek $ p'_gpgme_signature'status sig
             summary <- peek $ p'_gpgme_signature'summary sig
-            fpr <- peek (p'_gpgme_signature'fpr sig) >>= BS.packCString
+            fprPtr <- peek (p'_gpgme_signature'fpr sig)
+            fpr <- if fprPtr == nullPtr then return BS.empty else BS.packCString fprPtr
             next <- peek $ p'_gpgme_signature'next sig
             xs <- go next
             return $ (GpgmeError status, toSignatureSummaries summary, fpr) : xs

--- a/src/Crypto/Gpgme/Internal.hs
+++ b/src/Crypto/Gpgme/Internal.hs
@@ -13,9 +13,9 @@ import System.IO.Unsafe (unsafePerformIO)
 
 import Crypto.Gpgme.Types
 
--- The struct is read field by field via the p' accessors: peeking a whole
--- C'_gpgme_invalid_key diverges because its Storable instance recursively
--- peeks the mistyped @next@ field.
+-- Fields are read via the p' accessors: peeking a whole C'_gpgme_invalid_key
+-- diverges because its Storable instance recursively peeks the mistyped
+-- @next@ field.
 collectFprs :: C'gpgme_invalid_key_t -> [InvalidKey]
 collectFprs = unsafePerformIO . go
     where go :: C'gpgme_invalid_key_t -> IO [InvalidKey]
@@ -66,9 +66,7 @@ collectSignatures ctx = unsafePerformIO $ collectSignatures' ctx
 collectSignatures' :: C'gpgme_ctx_t -> IO VerificationResult
 collectSignatures' ctx = do
     verify_res <- c'gpgme_op_verify_result ctx
-    -- gpgme_op_verify_result returns NULL if the last operation on the
-    -- context was not a successful verify (e.g. it failed to even start
-    -- because of a bad homedir or missing engine)
+    -- NULL unless the last operation on the context was a successful verify
     if verify_res == nullPtr
         then return []
         else go =<< peek (p'_gpgme_op_verify_result'signatures verify_res)

--- a/test/InternalTest.hs
+++ b/test/InternalTest.hs
@@ -18,8 +18,8 @@ tests =
     , testCase "verifyGarbageDoesNotCrash" verifyGarbageDoesNotCrash
     ]
 
--- gpgme_op_verify_result returns NULL when no successful verify ran on
--- the context; this used to segfault (see stackoverflow question 48908274)
+-- gpgme_op_verify_result returns NULL when no successful verify ran on the
+-- context, which used to segfault (stackoverflow.com/questions/48908274)
 collectSignaturesWithoutVerify :: Assertion
 collectSignaturesWithoutVerify = do
     _ <- c'gpgme_check_version nullPtr

--- a/test/InternalTest.hs
+++ b/test/InternalTest.hs
@@ -1,0 +1,54 @@
+{-# LANGUAGE OverloadedStrings #-}
+module InternalTest (tests) where
+
+import Bindings.Gpgme
+import Foreign
+import Foreign.C.String (newCString)
+import Test.Tasty (TestTree)
+import Test.Tasty.HUnit (testCase)
+import Test.HUnit
+
+import Crypto.Gpgme
+import Crypto.Gpgme.Internal
+
+tests :: [TestTree]
+tests =
+    [ testCase "collectSignaturesWithoutVerify" collectSignaturesWithoutVerify
+    , testCase "collectFprsWalksList" collectFprsWalksList
+    , testCase "verifyGarbageDoesNotCrash" verifyGarbageDoesNotCrash
+    ]
+
+-- gpgme_op_verify_result returns NULL when no successful verify ran on
+-- the context; this used to segfault (see stackoverflow question 48908274)
+collectSignaturesWithoutVerify :: Assertion
+collectSignaturesWithoutVerify = do
+    _ <- c'gpgme_check_version nullPtr
+    ctxPtr <- malloc
+    checkError "gpgme_new" =<< c'gpgme_new ctxPtr
+    ctx <- peek ctxPtr
+    sigs <- collectSignatures' ctx
+    c'gpgme_release ctx
+    free ctxPtr
+    assertEqual "expected no signatures" [] sigs
+
+-- collectFprs used to diverge on any non-empty list because peeking a
+-- whole C'_gpgme_invalid_key recurses via its mistyped next field
+collectFprsWalksList :: Assertion
+collectFprsWalksList = do
+    second <- newInvalidKey "BBBB" 2 nullPtr
+    first <- newInvalidKey "AAAA" 1 second
+    assertEqual "expected both invalid keys" [("AAAA", 1), ("BBBB", 2)] (collectFprs first)
+  where
+    newInvalidKey fpr reason next = do
+        ptr <- mallocBytes (sizeOf (undefined :: C'_gpgme_invalid_key))
+        poke (castPtr (p'_gpgme_invalid_key'next ptr)) next
+        poke (p'_gpgme_invalid_key'fpr ptr) =<< newCString fpr
+        poke (p'_gpgme_invalid_key'reason ptr) reason
+        return ptr
+
+verifyGarbageDoesNotCrash :: Assertion
+verifyGarbageDoesNotCrash = do
+    res <- verify' "test/bob" "this is not a signature"
+    case res of
+        Left _ -> return ()
+        Right r -> assertFailure ("expected verification error, got: " ++ show r)

--- a/test/Main.hs
+++ b/test/Main.hs
@@ -6,13 +6,15 @@ import KeyTest
 import KeyGenTest
 import CtxTest
 import CryptoTest
+import InternalTest
 
 main :: IO ()
 main = do
     passphraseCbTests <- CryptoTest.cbTests
     keyCbTests <- KeyTest.cbTests
     defaultMain $ testGroup "tests"
-        [ testGroup "key"    KeyTest.tests
+        [ testGroup "internal" InternalTest.tests
+        , testGroup "key"    KeyTest.tests
         , keyCbTests
         , testGroup "keyGen" KeyGenTest.tests
         , testGroup "ctx"    CtxTest.tests


### PR DESCRIPTION
A user reported a segfault when checking signatures (https://stackoverflow.com/questions/48908274/using-crypto-gpgme-to-check-signatures). The gpgme docs state that the pointer returned by `gpgme_op_verify_result` is only valid if the verify operation finished successfully — when it fails to even start (e.g. an invalid homedir, which is what happened on StackOverflow), gpgme returns NULL and `collectSignatures'` dereferenced it unconditionally, crashing `verify`, `verifyDetached` and `verifyPlain`. `verifyInternal` now only reads the result on success, and `collectSignatures'` NULL-checks it either way since gpgme 1.x and 2.x differ in when they allocate the result.

While reproducing this, two more crashes of the same class turned up:

- `collectFprs` diverged on any non-empty invalid-key list: the Storable instance of `C'_gpgme_invalid_key` in bindings-gpgme recursively peeks its own mistyped `next` field, so peeking the struct never terminates. It also never checked for the end of the list. The list is now walked via the `p'` field accessors with a NULL termination check. (The mistyped field should eventually be fixed upstream in bindings-gpgme.)
- `newCtx` ran `peekCString` on the engine version, which gpgme documents as NULL when the engine binary is not installed; it now falls back to an empty string.

NULL fingerprint fields are mapped to empty strings instead of being dereferenced, for the same reason.

Each crash is covered by a regression test in the new `InternalTest` module: the verify-result case segfaulted (SIGSEGV) and the invalid-key case hung forever before the fix.